### PR TITLE
Handle route [...]/event/dates as _admin_route like rng

### DIFF
--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -59,6 +59,7 @@ class RouteSubscriber extends RouteSubscriberBase {
         ];
         $options = [];
         $options['parameters'][$entity_type]['type'] = 'entity:' . $entity_type;
+        $options['_admin_route'] = TRUE;
 
         $route = new Route(
           $canonical_path . '/event/dates',


### PR DESCRIPTION
In contrast to rng (all other local tasks) this is missing the _admin_route = TRUE; setting.