### PR TITLE
Update dependencies in rng_date_scheduler.info.yml

### DIFF
--- a/rng_date_scheduler.info.yml
+++ b/rng_date_scheduler.info.yml
@@ -4,5 +4,5 @@ description: 'Control whether a user can register based on current time in relat
 package: RNG
 core: 8.x
 dependencies:
-  - rng (>= 8.x-1.0)
-  - datetime
+  - rng:rng (>= 8.x-1.0)
+  - drupal:datetime


### PR DESCRIPTION
All dependencies must be prefixed by project name, So please <a href="https://www.drupal.org/docs/8/creating-custom-modules/let-drupal-8-know-about-your-module-with-an-infoyml-file">apply new {project}:{module} format for dependencies in info.yml file</a>
<p>It is supported since 8.0 and 7.40 Change Record: <a href="https://www.drupal.org/node/2299747">Project namespaces can now be added for module dependencies</a>, and is now a Best Practice <a href="https://www.drupal.org/project/drupal/issues/2798891">Define project dependencies in core module .info files</a>).</p><p>
It is useful for DrupalCi to download the right dependencies and Installation profiles to work well. So sooner is better.
Hope this helps.</p>